### PR TITLE
Add a contract for apply

### DIFF
--- a/data/collection/collection.rkt
+++ b/data/collection/collection.rkt
@@ -11,6 +11,7 @@
          (prefix-in u: (multi-in unstable [function list]))
          match-plus
          static-rename
+         kw-utils/kw-hash/contract
          "countable.rkt"
          "private/util.rkt")
 
@@ -48,7 +49,7 @@
                                     #:rest (tuple-listof exact-nonnegative-integer?
                                                          (any/c . -> . any/c))
                                     . ->* . sequence?*)]
-  [apply ([procedure?] #:rest (list-ending-with sequence?*) . ->* . any)]
+  [apply ([procedure?] #:rest (list-ending-with sequence?*) #:kws any/c . kw-hash-> . any)]
   [append ([] #:rest (listof sequence?*) . ->* . sequence?*)]
   [filter ((any/c . -> . any/c) sequence?* . -> . sequence?*)]
   [map (->i ([proc (seqs) (and/c (procedure-arity-includes/c (b:length seqs))

--- a/data/collection/collection.rkt
+++ b/data/collection/collection.rkt
@@ -22,7 +22,7 @@
 (provide
  gen:collection (rename-out [collection?* collection?]) collection/c
  gen:sequence (rename-out [sequence?* sequence?]) sequence/c
- apply in for/sequence for*/sequence for/sequence/derived for*/sequence/derived
+ in for/sequence for*/sequence for/sequence/derived for*/sequence/derived
  (contract-out
   ; gen:collection
   [extend (collection?* sequence?* . -> . collection?*)]
@@ -48,6 +48,7 @@
                                     #:rest (tuple-listof exact-nonnegative-integer?
                                                          (any/c . -> . any/c))
                                     . ->* . sequence?*)]
+  [apply ([procedure?] #:rest (list-ending-with sequence?*) . ->* . any)]
   [append ([] #:rest (listof sequence?*) . ->* . sequence?*)]
   [filter ((any/c . -> . any/c) sequence?* . -> . sequence?*)]
   [map (->i ([proc (seqs) (and/c (procedure-arity-includes/c (b:length seqs))
@@ -312,12 +313,8 @@
 ; validates the arguments passed to apply and converts the final argument to a list from a sequence
 (define (parse-apply-arguments args)
   (define fn (first args))
-  (when (not (procedure? fn))
-    (b:apply raise-argument-error 'apply "procedure?" 0 args))
   (define main-args (rest args))
   (define-values (init last) (b:split-at main-args (sub1 (length main-args))))
-  (when (not (sequence? (b:first last)))
-    (b:apply raise-argument-error 'apply "sequence?" (sub1 (length main-args)) args))
   (define last* (reverse (extend '() (b:first last))))
   (values fn (b:append init (list last*))))
 

--- a/data/collection/private/test/sequence.rkt
+++ b/data/collection/private/test/sequence.rkt
@@ -61,11 +61,11 @@
 
 (test-case
  "Sequence-based application"
- (check-equal? (apply +) 0)
  (check-equal? (apply + #(1 1 1)) 3)
  (check-equal? (apply + 1 1 #(1)) 3)
  (check-equal? (apply string-replace #("foo" "o" "a")) "faa")
  (check-equal? (apply string-replace #:all? #f #("foo" "o" "a")) "fao")
+ (check-exn exn:fail:contract? (thunk (apply +)))
  (check-exn exn:fail:contract? (thunk (apply 'not-a-fn #())))
  (check-exn exn:fail:contract? (thunk (apply + 'not-a-seq)))
  (check-exn exn:fail:contract? (thunk (apply)))
@@ -125,7 +125,8 @@
  (check-exn #rx"which is mutable" (thunk (empty? (vector))))
  (check-exn #rx"which is mutable" (thunk (empty? (make-hash))))
  (check-exn #rx"which is mutable" (thunk (empty? (mutable-set))))
- (check-exn #rx"expected: sequence\\?\n" (thunk (empty? 'not-a-sequence))))
+ (check-exn #rx"expected: sequence\\?\n" (thunk (empty? 'not-a-sequence)))
+ (check-exn #rx"which is mutable" (thunk (apply + (vector 1 2 3)))))
 
 (test-case
  "Good error messages for finite sequences"

--- a/data/collection/private/util.rkt
+++ b/data/collection/private/util.rkt
@@ -1,11 +1,12 @@
 #lang racket/base
 
-(require
-  racket/contract)
+(require racket/contract
+         racket/list)
 
 (provide
  (contract-out
-  [tuple-listof ([] #:rest (listof contract?) . ->* . contract?)]))
+  [tuple-listof ([] #:rest (listof contract?) . ->* . contract?)]
+  [list-ending-with (contract? . -> . contract?)]))
 
 ; adapted from plistof from unstable/gui/redex
 (define (tuple-listof . ctcs)
@@ -15,3 +16,71 @@
   (define tuple/c
     (foldr cons/c ctc ctcs))
   ctc)
+
+; a contract for lists that terminate with a particular element; used by `apply`
+(define (add-list-ending-with-context blame)
+  (blame-add-context blame "the last element of"))
+
+(define (list-ending-with-name ctc)
+  (build-compound-type-name 'list-ending-with (base-list-ending-with-ctc ctc)))
+
+(define ((list-ending-with-first-order ctc) val)
+  (and (list? val)
+       (not (empty? val))
+       (contract-first-order-passes? (base-list-ending-with-ctc ctc) (last val))))
+
+(define (list-ending-with-stronger? a b)
+  (contract-stronger? (base-list-ending-with-ctc a)
+                      (base-list-ending-with-ctc b)))
+
+(define ((list-ending-with-ho-projection flat?) ctc)
+  (let* ([elem-ctc (base-list-ending-with-ctc ctc)]
+         [pos-elem-first-proj (contract-projection elem-ctc)])
+    (λ (blame)
+      (let* ([passthrough-blame (blame-add-context blame #f)]
+             [context-blame (add-list-ending-with-context blame)]
+             [pos-elem-proj (pos-elem-first-proj context-blame)])
+        (λ (val)
+          (when (empty? val)
+            (raise-blame-error passthrough-blame val
+                               '(given: "'()" expected: "a non-empty list")))
+          (if flat?
+              (pos-elem-proj (last val))
+              (foldr (λ (elem acc) (cons (if (empty? acc)
+                                             (pos-elem-proj elem)
+                                             elem)
+                                         acc))
+                     '() val)))))))
+
+(struct base-list-ending-with (ctc))
+
+(struct flat-list-ending-with base-list-ending-with ()
+  #:property prop:flat-contract
+  (build-flat-contract-property
+   #:name list-ending-with-name
+   #:first-order list-ending-with-first-order
+   #:stronger list-ending-with-stronger?
+   #:projection (list-ending-with-ho-projection #t)
+   #:list-contract? (λ _ #t)))
+
+(struct chaperone-list-ending-with base-list-ending-with ()
+  #:property prop:chaperone-contract
+  (build-chaperone-contract-property
+   #:name list-ending-with-name
+   #:first-order list-ending-with-first-order
+   #:stronger list-ending-with-stronger?
+   #:projection (list-ending-with-ho-projection #f)))
+
+(struct impersonator-list-ending-with base-list-ending-with ()
+  #:property prop:contract
+  (build-contract-property
+   #:name list-ending-with-name
+   #:first-order list-ending-with-first-order
+   #:stronger list-ending-with-stronger?
+   #:projection (list-ending-with-ho-projection #f)))
+
+(define (list-ending-with v)
+  (let ([ctc (coerce-contract 'list-ending-with v)])
+    (cond [(flat-contract? ctc)      (flat-list-ending-with ctc)]
+          [(chaperone-contract? ctc) (chaperone-list-ending-with ctc)]
+          [else                      (impersonator-list-ending-with ctc)])))

--- a/info.rkt
+++ b/info.rkt
@@ -10,6 +10,7 @@
     "match-plus"
     "rackunit-lib"
     "static-rename"
+    "kw-utils"
     "unstable-list-lib"))
 (define build-deps
   '("racket-doc"


### PR DESCRIPTION
An alternate solution for https://github.com/lexi-lambda/racket-collections/issues/5. This uses a function contract combinator that allows arbitrary keyword arguments, with `(list-ending-with sequence?*)` as the rest contract.
The error message is:

```
. . apply: contract violation
  expected: sequence?, which must be immutable
  given: '#(1 2 3), which is mutable
  in: the last element of
      the rest argument of
      (kw-hash->
       (procedure?)
       #:rest
       (list-ending-with sequence?)
       #:kws
       any/c
       any)
  contract from: 
      <pkgs>/collections/data/collection/collection.rkt
  blaming: anonymous-module
   (assuming the contract is correct)
  at: <pkgs>/collections/data/collection/collection.rkt:52.3
```
