### PR TITLE
Use a custom contract for “apply” to include sequence?* annotation

### DIFF
--- a/data/collection/private/test/sequence.rkt
+++ b/data/collection/private/test/sequence.rkt
@@ -61,11 +61,11 @@
 
 (test-case
  "Sequence-based application"
- (check-equal? (apply +) 0)
  (check-equal? (apply + #(1 1 1)) 3)
  (check-equal? (apply + 1 1 #(1)) 3)
  (check-equal? (apply string-replace #("foo" "o" "a")) "faa")
  (check-equal? (apply string-replace #:all? #f #("foo" "o" "a")) "fao")
+ (check-exn exn:fail:contract? (thunk (apply +)))
  (check-exn exn:fail:contract? (thunk (apply 'not-a-fn #())))
  (check-exn exn:fail:contract? (thunk (apply + 'not-a-seq)))
  (check-exn exn:fail:contract? (thunk (apply)))
@@ -125,7 +125,8 @@
  (check-exn #rx"which is mutable" (thunk (empty? (vector))))
  (check-exn #rx"which is mutable" (thunk (empty? (make-hash))))
  (check-exn #rx"which is mutable" (thunk (empty? (mutable-set))))
- (check-exn #rx"expected: sequence\\?\n" (thunk (empty? 'not-a-sequence))))
+ (check-exn #rx"expected: sequence\\?\n" (thunk (empty? 'not-a-sequence)))
+ (check-exn #rx"which is mutable" (thunk (apply + (vector 1 2 3)))))
 
 (test-case
  "Good error messages for finite sequences"


### PR DESCRIPTION
@AlexKnauth @rfindler This implements a wholly custom contract for `apply`, as recommended in #6. I’ve opted to use a custom contract because I think it’s the only way to use the contract system and get reasonably good error reporting.

Robby, do you have any comments on the implementation of this contract/any ways it could be improved? Do you think this error message is comprehensible?

``` racket
(apply + (vector 1 2 3))
```

```
apply: contract violation
  expected: sequence?, which must be immutable
  given: '#(1 2 3), which is mutable
  in: the last argument of
      (-> procedure? any/c ... sequence? any)
```

Specifically, is it okay to use `->` in the error message with custom syntax? Or is it a no-no to dilute the meaning of the built-in contract operators?
