### PR TITLE
Indicate correct method in the support error raised in reverse

### DIFF
--- a/collections-doc/scribblings/data/collection/collection/reference.scrbl
+++ b/collections-doc/scribblings/data/collection/collection/reference.scrbl
@@ -209,6 +209,9 @@ arguments (including the @racket[seq] argument) or a contract error will be rais
 Returns a new sequence with all the elements of @racket[seq], but in reverse order. If @racket[seq] is
 infinite, this may not terminate.
 
+A default implementation is provided for this method for many built-in sequences, as well as for any
+custom sequence that is @racket[random-access?].
+
 @(coll-examples
   (reverse '(1 2 3))
   (reverse #(1 2 3))

--- a/collections-lib/data/collection/collection.rkt
+++ b/collections-lib/data/collection/collection.rkt
@@ -122,7 +122,7 @@
 (define (-reverse seq)
   (if (and (random-access? seq) (sequence-implements? seq 'nth))
       (reverse (wrap-random-access-sequence seq))
-      (raise-support-error 'rest seq)))
+      (raise-support-error 'reverse seq)))
 
 (define (-nth seq index)
   (if (zero? index)


### PR DESCRIPTION
Hi!
Attempting `reverse` on a sequence that does not explicitly implement it generates an error resembling:
```
; rest: not implemented for (function '(#<procedure:add1> #<procedure:sub1>))
; Context:
;  /Applications/Racket v7.5/collects/racket/repl.rkt:11:26
```

This fixes the typo to indicate the correct source.
