### PR TITLE
Fix bounded sequence exceeding bounds

### DIFF
--- a/collections-lib/data/collection/sequence.rkt
+++ b/collections-lib/data/collection/sequence.rkt
@@ -242,7 +242,7 @@
   #:reflection-name 'lazy-sequence
   #:methods gen:countable
   [(define/match* (length (bounded-seq _ left)) left)
-   (define (known-finite seq) #t)]
+   (define (known-finite? seq) #t)]
   #:methods gen:sequence
   [(define/generic -first first)
    (define/generic -rest rest)

--- a/collections-test/tests/data/collection/sequence-lib.rkt
+++ b/collections-test/tests/data/collection/sequence-lib.rkt
@@ -90,6 +90,14 @@
  (check-equal? (sequence->list (build-sequence 5 (λ _ 'a))) '(a a a a a)))
 
 (test-case
+  "Bounded sequences"
+  (check-equal? (length (take 3 (in-naturals))) 3)
+  (check-equal? (nth (take 3 (in-naturals)) 2) 2)
+  (check-exn exn:fail:contract? (thunk (take 5 (take 3 (in-naturals)))))
+  (check-exn exn:fail:contract? (thunk (fifth (take 3 (in-naturals)))))
+  (check-exn exn:fail:contract? (thunk (nth (take 3 (in-naturals)) 23))))
+
+(test-case
  "Infinite sequence constructors"
  (check-equal? (first (repeat 'foo)) 'foo)
  (check-equal? (nth (repeat 'foo) 10000) 'foo)


### PR DESCRIPTION
Hello!
I came across this bug:

```
sequence.rkt> (fifth (take 3 (naturals)))
4

sequence.rkt> (sequence->list (take 5 (take 3 (naturals))))
'(0 1 2 3 4)

sequence.rkt> (nth (take 3 (naturals)) 23)
23
```

Looks like a method name for the `gen:countable` implementation was wrong, fixed that and added tests. Here's the current output for the above:

```
sequence.rkt> (fifth (take 3 (naturals)))
; nth: index is out of range
;   index: 4
;   valid range: [0, 2]
;   sequence: #<lazy-sequence>
; Context:
;  .../collection/collection.rkt:81:0 body of "/Users/siddhartha/work/lisp/racket/racket-collections/collections-lib/data/collection/sequence.rkt"
;  .../racket/repl.rkt:11:26



sequence.rkt> (sequence->list (take 5 (take 3 (naturals))))
; take: length index is out of range
;   length index: 5
;   valid range: [0, 3]
;   sequence: #<lazy-sequence>
; Context:
;  /Users/siddhartha/work/lisp/racket/racket-collections/collections-lib/data/collection/sequence.rkt:263:0 body of "/Users/siddhartha/work/lisp/racket/racket-collections/collections-lib/data/collection/sequence.rkt"
;  .../racket/repl.rkt:11:26


sequence.rkt> (nth (take 3 (naturals)) 23)
; nth: index is out of range
;   index: 23
;   valid range: [0, 2]
;   sequence: #<lazy-sequence>
; Context:
;  .../collection/collection.rkt:81:0 body of "/Users/siddhartha/work/lisp/racket/racket-collections/collections-lib/data/collection/sequence.rkt"
;  .../racket/repl.rkt:11:26

```