### PR TITLE
Fix conj* and extend* contracts to expect collections

### DIFF
--- a/collections-lib/data/collection/collection.rkt
+++ b/collections-lib/data/collection/collection.rkt
@@ -40,8 +40,8 @@
   [sequence->collection (sequence?* . -> . collection?*)]
   [random-access? (sequence?* . -> . boolean?)]
   ; derived functions
-  [extend* ([collection?*] #:rest (listof sequence?*) . ->* . sequence?*)]
-  [conj* ([collection?*] #:rest any/c . ->* . sequence?*)]
+  [extend* ([collection?*] #:rest (listof sequence?*) . ->* . collection?*)]
+  [conj* ([collection?*] #:rest any/c . ->* . collection?*)]
   [rename set-nth** set-nth* ([sequence?*]
                               #:rest (tuple-listof exact-nonnegative-integer? any/c)
                               . ->* . sequence?*)]

--- a/collections-test/tests/data/collection/collection.rkt
+++ b/collections-test/tests/data/collection/collection.rkt
@@ -32,7 +32,14 @@
 (test-case
  "Collection abbreviations"
  (check-equal? (conj* '() 'a 'b 'c) '(c b a))
- (check-equal? (extend* '() '(a b c) #(1 2 3) (hash 'foo 'bar)) '((foo . bar) 3 2 1 c b a)))
+ (check-equal? (extend* '() '(a b c) #(1 2 3) (hash 'foo 'bar)) '((foo . bar) 3 2 1 c b a))
+ (struct bag (contents)
+   #:transparent
+   #:methods gen:collection
+   [(define (conj col elem)
+      (bag (cons elem (bag-contents col))))])
+ (check-equal? (conj* (bag (list 1 2 3)) 4) (bag (list 4 1 2 3)) "collection that isn't a sequence")
+ (check-equal? (extend* (bag (list 1 2 3)) (list 4) (list 5)) (bag (list 5 4 1 2 3)) "collection that isn't a sequence"))
 
 (test-case
  "Special contract errors on mutable builtins"


### PR DESCRIPTION
Fixes #23 by modifying the expected return values in the `conj*` and `extend*` contracts to be `collection?` instead of `sequence?` [[the docs](https://docs.racket-lang.org/collections/collections-api.html?q=data%2Fcollection#%28part._collection-functions%29) confirm that this is the intended output]